### PR TITLE
waffle.io Badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/rygos/rmarchiv.png?label=ready&title=Ready)](https://waffle.io/rygos/rmarchiv?utm_source=badge)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/rygos/rmarchiv/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/rygos/rmarchiv/?branch=master)
 [![StyleCI](https://styleci.io/repos/80870043/shield?branch=master)](https://styleci.io/repos/80870043)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/rygos/rmarchiv

This was requested by a real person (user rygos) on waffle.io, we're not trying to spam you.